### PR TITLE
Add basic Express server with SQLite database

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cours-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+const express = require("express");
+const sqlite3 = require("sqlite3").verbose();
+const path = require("path");
+
+const app = express();
+app.use(express.json());
+
+const dbPath = path.resolve(__dirname, "database.sqlite");
+const db = new sqlite3.Database(dbPath);
+
+app.get("/", (req, res) => {
+  res.send("Backend SQLite opérationnel !");
+});
+
+db.run(
+  "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT UNIQUE)"
+);
+
+app.post("/users", (req, res) => {
+  const { username } = req.body;
+  db.run("INSERT INTO users (username) VALUES (?)", [username], function (err) {
+    if (err) {
+      return res.status(400).json({ error: err.message });
+    }
+    res.json({ id: this.lastID, username });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Serveur lancé sur le port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add package manifest declaring express and sqlite3 dependencies
- implement minimal Express server with SQLite-backed users endpoint
- include empty SQLite database file for persistence

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3a97085748333a55aded3e20ab719