### PR TITLE
Ensure backend CORS middleware and ignore local DB file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-node_modules
-frontend/node_modules
-frontend/dist
+node_modules/
+frontend/node_modules/
+frontend/dist/
+database.sqlite
+data/
 .env
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "sqlite3": "^5.1.6"
   }


### PR DESCRIPTION
## Summary
- add the official `cors` middleware to the Express app and declare the dependency
- simplify the hole synchronization endpoint so it only upserts received holes
- extend the gitignore to drop the local SQLite database and data directory from version control

## Testing
- npm install *(fails: 403 Forbidden when contacting registry)*
- cd frontend && npm install *(fails: 403 Forbidden when contacting registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b7796b6c8333ba0c4807f6b6b606