### PR TITLE
Refine landing page experience

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,39 +81,54 @@ export default function App() {
   };
 
   const isLogged = Boolean(user);
-  const showCourse = isLogged && currentCourse;
+  const hasActiveCourse = Boolean(isLogged && currentCourse);
+
+  let content: JSX.Element | null = null;
+
+  if (!isLogged) {
+    content = <Login onLogged={handleLogin} />;
+  } else if (!hasActiveCourse) {
+    content = (
+      <Dashboard
+        userId={user!.id}
+        onOpenCourse={handleOpenCourse}
+        refreshKey={refreshCourses}
+      />
+    );
+  } else if (mode === "edit") {
+    content = (
+      <Editor courseId={currentCourse!.id} onCourseLoaded={handleCourseTitle} />
+    );
+  } else {
+    content = (
+      <Review
+        courseId={currentCourse!.id}
+        userId={user!.id}
+        refreshKey={refreshHoles}
+        onCourseLoaded={handleCourseTitle}
+      />
+    );
+  }
 
   return (
     <div className="app-container">
-      <Header
-        user={user}
-        courseTitle={currentCourse?.title}
-        showCourseActions={Boolean(showCourse)}
-        mode={mode}
-        onModeChange={setMode}
-        onBack={showCourse ? handleBackToDashboard : undefined}
-        onAdvanceIteration={showCourse ? handleAdvanceIteration : undefined}
-        iterationLoading={iterationLoading}
-      />
-      {!isLogged && <Login onLogged={handleLogin} />}
-      {isLogged && !showCourse && (
-        <Dashboard
-          userId={user!.id}
-          onOpenCourse={handleOpenCourse}
-          refreshKey={refreshCourses}
+      {isLogged && (
+        <Header
+          user={user}
+          courseTitle={currentCourse?.title}
+          showCourseActions={hasActiveCourse}
+          mode={mode}
+          onModeChange={setMode}
+          onBack={hasActiveCourse ? handleBackToDashboard : undefined}
+          onAdvanceIteration={
+            hasActiveCourse ? handleAdvanceIteration : undefined
+          }
+          iterationLoading={iterationLoading}
         />
       )}
-      {isLogged && showCourse && mode === "edit" && (
-        <Editor courseId={currentCourse!.id} onCourseLoaded={handleCourseTitle} />
-      )}
-      {isLogged && showCourse && mode === "review" && (
-        <Review
-          courseId={currentCourse!.id}
-          userId={user!.id}
-          refreshKey={refreshHoles}
-          onCourseLoaded={handleCourseTitle}
-        />
-      )}
+      <main className={isLogged ? "main-content" : "landing-content"}>
+        {content}
+      </main>
       {iterationMessage && (
         <div
           className={`status-bar ${

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ChangeEvent, type FormEvent } from "react";
 import { createUser, findUser, type User } from "../api/users";
 
 interface LoginProps {
@@ -10,7 +10,14 @@ export default function Login({ onLogged }: LoginProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUsername(event.target.value);
+    if (error) {
+      setError(null);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmed = username.trim();
     if (!trimmed) {
@@ -36,23 +43,40 @@ export default function Login({ onLogged }: LoginProps) {
   };
 
   return (
-    <div className="card">
-      <h2>Entrer dans l'application</h2>
-      <form onSubmit={handleSubmit}>
-        <label htmlFor="username">Pseudo</label>
+    <section className="card login-card">
+      <h1>Cours à trous – Apprends et révise efficacement</h1>
+      <p className="login-description">
+        Écris tes cours, transforme-les en texte à trous et révise-les grâce à un
+        système intelligent d'itérations.
+      </p>
+      <form className="login-form" onSubmit={handleSubmit}>
+        <label htmlFor="username">Ton pseudo</label>
         <input
           id="username"
           value={username}
-          onChange={(event) => setUsername(event.target.value)}
-          placeholder="Votre pseudo"
+          onChange={handleUsernameChange}
+          placeholder="Entre ton pseudo"
+          autoComplete="off"
+          autoFocus
         />
-        <div style={{ marginTop: "16px" }}>
+        <div className="login-actions">
           <button className="btn btn-primary" type="submit" disabled={loading}>
             {loading ? "Connexion..." : "Entrer"}
           </button>
         </div>
-        {error && <div className="status-bar alert-error">{error}</div>}
+        {error && (
+          <div
+            className="status-bar alert-error login-error"
+            role="alert"
+            aria-live="assertive"
+          >
+            {error}
+          </div>
+        )}
       </form>
-    </div>
+      <p className="login-helper">
+        Pas besoin de mot de passe – tout est basé sur ton pseudo.
+      </p>
+    </section>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -30,6 +30,100 @@ a {
   max-width: 960px;
   margin: 0 auto;
   padding: 24px 16px 48px;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-container > main {
+  width: 100%;
+}
+
+.landing-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.login-card {
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+  padding: 48px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.3;
+}
+
+.login-description {
+  margin: 0;
+  color: #475569;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+}
+
+.login-form label {
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.login-form input {
+  text-align: center;
+  font-size: 1.1rem;
+}
+
+.login-actions {
+  margin-top: 8px;
+}
+
+.login-actions .btn {
+  width: 100%;
+  padding: 12px 16px;
+}
+
+.login-card .status-bar {
+  text-align: center;
+}
+
+.login-helper {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.login-error {
+  margin-top: 12px;
+}
+
+@media (max-width: 600px) {
+  .login-card {
+    padding: 32px 24px;
+  }
+
+  .login-card h1 {
+    font-size: 1.6rem;
+  }
 }
 
 .card {


### PR DESCRIPTION
## Summary
- show the login screen inside a dedicated landing layout and hide the header before authentication
- refresh the login component with the required headline, description, helper text and inline validation
- extend the global styles to center the landing card and polish the hero form presentation

## Testing
- npm install *(fails: 403 Forbidden when downloading npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bb5cce9c833382c0d901c7a2168d